### PR TITLE
batch.tf: Use proper instance_role instead of semi-hardcoded one

### DIFF
--- a/batch.tf
+++ b/batch.tf
@@ -62,7 +62,7 @@ resource "aws_batch_compute_environment" "this" {
     max_vcpus           = 256
     desired_vcpus       = 0
     instance_type       = ["optimal"]
-    instance_role       = "arn:aws:iam::${var.account_id}:instance-profile/ecsInstanceRole"
+    instance_role       = aws_iam_instance_profile.default.arn
 
     security_group_ids = [
       module.batch_security_group[count.index].security_group_id


### PR DESCRIPTION
Using `"arn:aws:iam::${var.account_id}:instance-profile/ecsInstanceRole"` breaks dependency graph and causes `terraform apply` to break as IAM role was not existing during creation of batch environment.

With `aws_iam_instance_profile.default.arn` you change dependency graph so Terraform have to create `instance_role` before it can even try to create batch environment.