### PR TITLE
Fix deprecated argument

### DIFF
--- a/batch.tf
+++ b/batch.tf
@@ -49,10 +49,10 @@ resource "aws_launch_template" "this" {
 
 resource "aws_batch_compute_environment" "this" {
 
-  count                    = var.deploy_batch ? 1 : 0
-  compute_environment_name = var.name
-  service_role             = "arn:aws:iam::${var.account_id}:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch"
-  type                     = "MANAGED"
+  count        = var.deploy_batch ? 1 : 0
+  name         = var.name
+  service_role = "arn:aws:iam::${var.account_id}:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch"
+  type         = "MANAGED"
 
   compute_resources {
     type                = "SPOT"

--- a/iam.tf
+++ b/iam.tf
@@ -134,6 +134,21 @@ data "aws_iam_policy_document" "main" {
       "*"
     ]
   }
+
+  statement {
+    #checkov:skip=CKV_AWS_356:IAM policies documents allow "*"
+    effect = "Allow"
+
+    actions = [
+      "logs:GetLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_instance_profile" "default" {


### PR DESCRIPTION
Suddenly stopped working on the CLI, seems this is the fix.

```

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.[0m
[33m╷[0m[0m
[33m│[0m [0m[1m[33mWarning: [0m[0m[1mDeprecated attribute[0m
[33m│[0m [0m
[33m│[0m [0m[0m  on .terraform/modules/bootstrap.s3-bucket/main.tf line 584, in data "aws_iam_policy_document" "elb_log_delivery":
[33m│[0m [0m 584:     for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current[4m.name[0m }[0m
[33m│[0m [0m
[33m│[0m [0mThe attribute "name" is deprecated. Refer to the provider documentation for
[33m│[0m [0mdetails.
[33m╵[0m[0m
[31m╷[0m[0m
[31m│[0m [0m[1m[31mError: [0m[0m[1mUnsupported argument[0m
[31m│[0m [0m
[31m│[0m [0m[0m  on .terraform/modules/bootstrap/batch.tf line 53, in resource "aws_batch_compute_environment" "this":
[31m│[0m [0m  53:   [4mcompute_environment_name[0m = var.name[0m
[31m│[0m [0m
[31m│[0m [0mAn argument named "compute_environment_name" is not expected here.
[31m╵[0m[0m
```

Think there's another issue but not sure if that's the CLI TF or the public repo